### PR TITLE
reboot much faster in case of storage failure

### DIFF
--- a/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
+++ b/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
@@ -155,7 +155,7 @@ then
   exit 0
 elif [ "$cflag" == "1" ]
 then
-  reboot
+  echo b > /proc/sysrq-trigger
   exit $?
 else
   write_hbLog 


### PR DESCRIPTION
When storage cannot be reached, it does not make sense to reboot as it will try to flush buffers, umount NFS mounts, etc. This will not work and thus cause a long delay. With this change, the box will reboot immediately (like pressing the reset button).